### PR TITLE
Doesn't work without this patch

### DIFF
--- a/jirafs/utils.py
+++ b/jirafs/utils.py
@@ -190,7 +190,7 @@ def get_git_version():
         ['git', '--version'],
         stderr=subprocess.PIPE,
     ).decode('utf8')
-    version_string = re.match('git version ([0-9.]+) .*', result).group(1)
+    version_string = re.match('git version ([0-9.]+).*', result).group(1)
     return NormalizedVersion(version_string)
 
 


### PR DESCRIPTION
jirafs crashes for me. Basically there's no trailing space after the git version.. not sure why there would be? I'm using ZSH FWIW and git version returns

```
(g) mriehl@machine ~ $ git --version
git version 1.9.1
```

This is the error I get:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/data/home/mriehl/.virtualenvs/g/bin/jirafs in <module>()
      7 if __name__ == '__main__':
      8     sys.exit(
----> 9         load_entry_point('jirafs==0.9.9', 'console_scripts', 'jirafs')()
     10     )

/data/home/mriehl/.virtualenvs/g/local/lib/python2.7/site-packages/jirafs/cmdline.pyc in main()
    490             "python before using Jirafs."
    491         )
--> 492     if utils.get_git_version() < NormalizedVersion('1.8'):
    493         raise RuntimeError(
    494             "Jirafs requires minimally version 1.8 of Git.  Please "

/data/home/mriehl/.virtualenvs/g/local/lib/python2.7/site-packages/jirafs/utils.pyc in get_git_version()
    191         stderr=subprocess.PIPE,
    192     ).decode('utf8')
--> 193     version_string = re.match('git version ([0-9.]+) .*', result).group(1)
    194     return NormalizedVersion(version_string)
    195 

AttributeError: 'NoneType' object has no attribute 'group'
```

a540cd3 fixes the issue for me.
