### PR TITLE
add tests for git version matching

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,14 @@
 import mock
 
+from verlib import NormalizedVersion
+
 from jirafs import utils
 
 from .base import BaseTestCase
 
 
 class TestStashLocalChanges(BaseTestCase):
+
     def test_stash_local_changes(self):
         repo = mock.Mock()
         repo.version = 10
@@ -40,3 +43,22 @@ class TestStashLocalChanges(BaseTestCase):
             mock.call('stash', 'apply', failure_ok=True),
             mock.call('stash', 'drop', failure_ok=True),
         ])
+
+
+class TestParseGitVersion(BaseTestCase):
+
+    @mock.patch("jirafs.utils.subprocess.check_output")
+    def test_parse_osx_git_version(self, git_version_output):
+        git_version_output.return_value = b"git version 1.8.5.2 (Apple Git-48)"
+
+        actual_version = utils.get_git_version()
+
+        self.assertEqual(actual_version, NormalizedVersion("1.8.5.2"))
+
+    @mock.patch("jirafs.utils.subprocess.check_output")
+    def test_parse_linux_git_version(self, git_version_output):
+        git_version_output.return_value = b"git version 1.9.1"
+
+        actual_version = utils.get_git_version()
+
+        self.assertEqual(actual_version, NormalizedVersion("1.9.1"))


### PR DESCRIPTION
The git version differs according to packagers (e.G. brew vs deb) so the
git version parsing needs to deal with all known variants.
