### PR TITLE
Fix UnicodeEncodeError in merge command

### DIFF
--- a/jirafs/commands/merge.py
+++ b/jirafs/commands/merge.py
@@ -42,7 +42,7 @@ class Command(CommandPlugin):
             )
             for field, values in (jira_fields - master_fields).items():
                 folder.log(
-                    "Field {field} changed: \"{fr}\" -> \"{to}\"".format(
+                    u"Field {field} changed: \"{fr}\" -> \"{to}\"".format(
                         field=field,
                         fr=values[0],
                         to=values[1]

--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,4 @@ deps =
     mock
 sitepackages = False
 commands =
-    {envbindir}/py.test
+    {envbindir}/py.test {toxinidir}/tests


### PR DESCRIPTION
On a fresh `jirafs clone` I ran into a UnicodeEncodeError in the merge command:

```
Traceback (most recent call last):
  File "/home/sduncan/.local/bin/jirafs", line 9, in <module>
    load_entry_point('jirafs==1.10.1', 'console_scripts', 'jirafs')()
  File "/home/sduncan/.local/lib/python2.7/site-packages/jirafs/cmdline.py", line 71, in main
    extra, jira=jira, path=os.getcwd(), command_name=command_name
  File "/home/sduncan/.local/lib/python2.7/site-packages/jirafs/plugin.py", line 153, in execute_command
    result = cmd.handle(**kwargs)
  File "/home/sduncan/.local/lib/python2.7/site-packages/jirafs/commands/clone.py", line 37, in handle
    return self.clone(path, ticket_url, jira)
  File "/home/sduncan/.local/lib/python2.7/site-packages/jirafs/commands/clone.py", line 175, in clone
    jira,
  File "/home/sduncan/.local/lib/python2.7/site-packages/jirafs/commands/clone.py", line 46, in clone_from_issue
    utils.run_command_method_with_kwargs('pull', folder=folder)
  File "/home/sduncan/.local/lib/python2.7/site-packages/jirafs/utils.py", line 90, in run_command_method_with_kwargs
    return getattr(installed_commands[command](), method)(**kwargs)
  File "/home/sduncan/.local/lib/python2.7/site-packages/jirafs/commands/pull.py", line 17, in pull
    merge_result = run_command_method_with_kwargs('merge', folder=folder)
  File "/home/sduncan/.local/lib/python2.7/site-packages/jirafs/utils.py", line 90, in run_command_method_with_kwargs
    return getattr(installed_commands[command](), method)(**kwargs)
  File "/home/sduncan/.local/lib/python2.7/site-packages/jirafs/commands/merge.py", line 48, in merge
    to=values[1]
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 448: ordinal not in range(128)
```

I made a simple fix to get it to work for me. I didn't add a test for it, but was able to get `clone` to work after the patch.

I also had some trouble running tox for some of the tests. Without recreating the tox env everytime, the bare py.test was trying to run tests for any installed package.