### PR TITLE
Fix AttributeError when cloning a ticket without attachment

### DIFF
--- a/jirafs/ticketfolder.py
+++ b/jirafs/ticketfolder.py
@@ -669,7 +669,7 @@ class TicketFolder(object):
 
         assets = []
         attachments = self.filter_ignored_files(
-            self.issue.fields.attachment,
+            getattr(self.issue.fields, 'attachment', []),
             constants.REMOTE_IGNORE_FILE
         )
         for attachment in attachments:


### PR DESCRIPTION
When cloning an issue without attachments, I got:

```
Traceback (most recent call last):
  File "/home/kevin.qiu/src/jirafs/env/bin/jirafs", line 9, in <module>
    load_entry_point('jirafs==1.13.3', 'console_scripts', 'jirafs')()
  File "/home/kevin.qiu/src/jirafs/jirafs/cmdline.py", line 86, in main
    extra, jira=jira, path=os.getcwd(), command_name=command_name
  File "/home/kevin.qiu/src/jirafs/jirafs/plugin.py", line 172, in execute_command
    result = cmd.handle(**kwargs)
  File "/home/kevin.qiu/src/jirafs/jirafs/commands/clone.py", line 37, in handle
    return self.clone(path, ticket_url, jira)
  File "/home/kevin.qiu/src/jirafs/jirafs/commands/clone.py", line 175, in clone
    jira,
  File "/home/kevin.qiu/src/jirafs/jirafs/commands/clone.py", line 46, in clone_from_issue
    utils.run_command_method_with_kwargs('pull', folder=folder)
  File "/home/kevin.qiu/src/jirafs/jirafs/utils.py", line 90, in run_command_method_with_kwargs
    return getattr(installed_commands[command](), method)(**kwargs)
  File "/home/kevin.qiu/src/jirafs/jirafs/commands/pull.py", line 16, in pull
    fetch_result = run_command_method_with_kwargs('fetch', folder=folder)
  File "/home/kevin.qiu/src/jirafs/jirafs/utils.py", line 90, in run_command_method_with_kwargs
    return getattr(installed_commands[command](), method)(**kwargs)
  File "/home/kevin.qiu/src/jirafs/jirafs/commands/fetch.py", line 78, in fetch
    for filename in folder.get_remotely_changed():
  File "/home/kevin.qiu/src/jirafs/jirafs/ticketfolder.py", line 672, in get_remotely_changed
    self.issue.fields.attachment,
AttributeError: type object 'PropertyHolder' has no attribute 'attachment'
```