### PR TITLE
Fix the regex to parse raw_field_name

### DIFF
--- a/jirafs/jirafieldmanager.py
+++ b/jirafs/jirafieldmanager.py
@@ -162,7 +162,7 @@ class JiraFieldManager(dict):
                 if value:  # If so, we just need to store previous loop data
                     self.set_data_value(data, field_name, value)
                     value = ''
-                raw_field_name = re.match('^\* ([^:]+):$', line).group(1)
+                raw_field_name = re.match('^\* +(.*?)(\(.*?\)):$', line).group(1)
                 if '(' in raw_field_name:
                     # This field name's real name doesn't match the field ID
                     match = re.match(


### PR DESCRIPTION
This branch fixes the regex used to parse raw field names. 
I had a field name whose value was:
```
line = "*  Dr. Elephant link for the job: (customfield_14029):"
```
And the code failed with below exception:-
```
Traceback (most recent call last):
  File "/usr/local/bin/jirafs", line 9, in <module>
    load_entry_point('jirafs==1.13.4', 'console_scripts', 'jirafs')()
  File "/Library/Python/2.7/site-packages/jirafs/cmdline.py", line 86, in main
    extra, jira=jira, path=os.getcwd(), command_name=command_name
  File "/Library/Python/2.7/site-packages/jirafs/plugin.py", line 172, in execute_command
    result = cmd.handle(**kwargs)
  File "/Library/Python/2.7/site-packages/jirafs/commands/clone.py", line 37, in handle
    return self.clone(path, ticket_url, jira)
  File "/Library/Python/2.7/site-packages/jirafs/commands/clone.py", line 175, in clone
    jira,
  File "/Library/Python/2.7/site-packages/jirafs/commands/clone.py", line 46, in clone_from_issue
    utils.run_command_method_with_kwargs('pull', folder=folder)
  File "/Library/Python/2.7/site-packages/jirafs/utils.py", line 90, in run_command_method_with_kwargs
    return getattr(installed_commands[command](), method)(**kwargs)
  File "/Library/Python/2.7/site-packages/jirafs/commands/pull.py", line 17, in pull
    merge_result = run_command_method_with_kwargs('merge', folder=folder)
  File "/Library/Python/2.7/site-packages/jirafs/utils.py", line 90, in run_command_method_with_kwargs
    return getattr(installed_commands[command](), method)(**kwargs)
  File "/Library/Python/2.7/site-packages/jirafs/commands/merge.py", line 38, in merge
    folder, revision='jira'
  File "/Library/Python/2.7/site-packages/jirafs/jirafieldmanager.py", line 124, in create
    return GitRevisionJiraFieldManager(folder, revision)
  File "/Library/Python/2.7/site-packages/jirafs/readers.py", line 11, in __init__
    super(GitRevisionReader, self).__init__()
  File "/Library/Python/2.7/site-packages/jirafs/jirafieldmanager.py", line 186, in __init__
    data, names = self.load()
  File "/Library/Python/2.7/site-packages/jirafs/jirafieldmanager.py", line 193, in load
    self.get_file_contents(constants.TICKET_DETAILS)
  File "/Library/Python/2.7/site-packages/jirafs/jirafieldmanager.py", line 165, in get_fields_from_string
    raw_field_name = re.match('^\* ([^:]+):$', line).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```
The updated regex handles handles that condition and doesn't assume that the ```long name``` won't contain ```:```. 

Let me know your concerns! 