### PR TITLE
Add the ability to store encrypted JIRA passwords

### DIFF
--- a/jirafs/password.py
+++ b/jirafs/password.py
@@ -1,0 +1,38 @@
+import scrypt
+
+
+password = None
+
+
+def encrypt_password(password, passphrase):
+    return scrypt.encrypt(password, passphrase)
+
+
+def decrypt_password(hashed_password, passphrase):
+    try:
+        return scrypt.decrypt(hashed_password, passphrase)
+    except:
+        return False
+
+
+def cache_password(p):
+    global password
+    password = p
+
+
+def get_password_from_login_data(login_data):
+    from . import utils
+    global password
+    if password is not None:
+        login_data.pop('password', None)
+        return password
+
+    password = login_data.pop('password')
+    password_encrypted = login_data.pop('password_encrypted', False)
+    if password_encrypted:
+        passphrase = utils.get_user_input('Passphrase: ', password=True)
+        password = decrypt_password(password, passphrase)
+        if not password:
+            raise ValueError('Cannot use the passphrase to decrypt the encrypted JIRA password')
+
+    return password

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ blessings>=1.5.1,<1.6.0
 ipdb>=0.8,<1.0
 verlib>=0.1,<1.0
 prettytable>=0.7.2,<1.0
+scrypt>=0.7

--- a/tests/test_password.py
+++ b/tests/test_password.py
@@ -1,0 +1,54 @@
+import pytest
+from mock import sentinel, patch, call
+
+import jirafs.password
+from jirafs.password import get_password_from_login_data
+
+
+class TestGetPasswordFromLoginData(object):
+    def test_should_return_cached_password(self):
+        jirafs.password.password = sentinel.PASSWORD
+        assert sentinel.PASSWORD == get_password_from_login_data({})
+
+    def test_should_return_cached_password_and_remove_login_password(self):
+        jirafs.password.password = sentinel.PASSWORD
+        login_data = {'password': sentinel.LOGIN_PASSWORD}
+        assert sentinel.PASSWORD == get_password_from_login_data(login_data)
+        assert 'password' not in login_data
+
+    def test_should_return_plain_text_password_if_no_password_cached_and_no_password_encrypted_flag(self):
+        jirafs.password.password = None
+        login_data = {'password': sentinel.LOGIN_PASSWORD}
+        assert sentinel.LOGIN_PASSWORD == get_password_from_login_data(login_data)
+        assert 'password' not in login_data
+
+    def test_should_return_plain_text_password_if_no_password_cached_and_password_encrypted_flag_set_to_false(self):
+        jirafs.password.password = None
+        login_data = {'password': sentinel.LOGIN_PASSWORD, 'password_encrypted': False}
+        assert sentinel.LOGIN_PASSWORD == get_password_from_login_data(login_data)
+        assert 'password' not in login_data
+
+    @patch('jirafs.password.scrypt')
+    @patch('jirafs.utils.get_user_input')
+    def test_should_return_decrypted_password_if_password_encrypted_flag_is_set(
+            self, mock_get_user_input,  mock_scrypt):
+        mock_scrypt.decrypt.return_value = sentinel.DECRYPTED_PASSWORD
+        mock_get_user_input.return_value = sentinel.PASSPHRASE
+        jirafs.password.password = None
+        login_data = {'password': sentinel.LOGIN_PASSWORD, 'password_encrypted': True}
+        assert sentinel.DECRYPTED_PASSWORD == get_password_from_login_data(login_data)
+        assert 'password' not in login_data
+        assert [call(sentinel.LOGIN_PASSWORD, sentinel.PASSPHRASE)] == mock_scrypt.decrypt.call_args_list
+
+    @patch('jirafs.password.scrypt')
+    @patch('jirafs.utils.get_user_input')
+    def test_should_raise_error_if_exception_encountered_during_decryption(
+            self, mock_get_user_input,  mock_scrypt):
+        mock_scrypt.decrypt.side_effect = Exception
+        mock_get_user_input.return_value = sentinel.PASSPHRASE
+        jirafs.password.password = None
+        login_data = {'password': sentinel.LOGIN_PASSWORD, 'password_encrypted': True}
+        with pytest.raises(ValueError):
+            get_password_from_login_data(login_data)
+        assert 'password' not in login_data
+        assert [call(sentinel.LOGIN_PASSWORD, sentinel.PASSPHRASE)] == mock_scrypt.decrypt.call_args_list


### PR DESCRIPTION
Our ops are not comfortable with the JIRA password (which happens to be our active directory password) sitting in our home folder unencrypted. This PR adds the ability to encrypt the JIRA password with a passphrase using scrypt.

Let me know what you think :)