### PR TITLE
Read configuration values as literal strings

### DIFF
--- a/jirafs/utils.py
+++ b/jirafs/utils.py
@@ -131,7 +131,7 @@ def get_config(additional_configs=None, include_global=True):
     if additional_configs:
         filenames.extend(additional_configs)
 
-    parser = configparser.ConfigParser()
+    parser = configparser.RawConfigParser()
     parser.read(filenames)
     return parser
 


### PR DESCRIPTION
Closes #42

Configuration values were read using ConfigParser, which does string interpolation, for instance making it impossible to use "%". This commit switches to RawConfigParser to avoid any special treatment of configuration values.