### PR TITLE
Replace obsolete verlib with distutils.version.

### DIFF
--- a/jirafs/cmdline.py
+++ b/jirafs/cmdline.py
@@ -16,7 +16,7 @@ except ImportError:
     from jira.exceptions import JIRAError
 import six
 from six.moves import shlex_quote
-from verlib import NormalizedVersion
+from distutils.version import LooseVersion
 
 from . import utils
 from .exceptions import (
@@ -43,7 +43,7 @@ def main():
             "any version of Python 3.  Please upgrade your version of "
             "python before using Jirafs."
         )
-    if utils.get_git_version() < NormalizedVersion('1.8'):
+    if utils.get_git_version() < LooseVersion('1.8'):
         raise RuntimeError(
             "Jirafs requires minimally version 1.8 of Git.  Please "
             "upgrade your version of git before using Jirafs."

--- a/jirafs/plugin.py
+++ b/jirafs/plugin.py
@@ -9,7 +9,7 @@ import sys
 
 from blessings import Terminal
 import six
-from verlib import NormalizedVersion
+from distutils.version import LooseVersion
 
 from . import __version__
 
@@ -120,9 +120,9 @@ class JirafsPluginBase(object):
                 "Minimum and maximum version numbers not specified."
             )
 
-        min_version = NormalizedVersion(self.MIN_VERSION)
-        max_version = NormalizedVersion(self.MAX_VERSION)
-        curr_version = NormalizedVersion(__version__)
+        min_version = LooseVersion(self.MIN_VERSION)
+        max_version = LooseVersion(self.MAX_VERSION)
+        curr_version = LooseVersion(__version__)
         if not min_version <= curr_version <= max_version:
             raise PluginValidationError(
                 "Plugin '%s' is not compatible with version %s of Jirafs; "

--- a/jirafs/utils.py
+++ b/jirafs/utils.py
@@ -8,7 +8,7 @@ import subprocess
 
 from jira.client import JIRA
 from six.moves import configparser, input
-from verlib import NormalizedVersion
+from distutils.version import LooseVersion
 
 from . import constants
 from .plugin import CommandPlugin, Plugin
@@ -270,7 +270,7 @@ def get_git_version():
         stderr=subprocess.PIPE,
     ).decode('utf8')
     version_string = re.match('git version ([0-9.]+).*', result).group(1)
-    return NormalizedVersion(version_string)
+    return LooseVersion(version_string)
 
 
 def lazy_get_jira():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 jira>=1.0.3
 six>=1.9.0
 blessings>=1.5.1,<2.0
-verlib>=0.1,<1.0
 prettytable>=0.7.2,<1.0
 environmental-override>=0.1.2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import mock
 
-from verlib import NormalizedVersion
+from distutils.version import LooseVersion
 
 from jirafs import utils
 
@@ -43,7 +43,7 @@ class TestParseGitVersion(BaseTestCase):
 
         actual_version = utils.get_git_version()
 
-        self.assertEqual(actual_version, NormalizedVersion("1.8.5.2"))
+        self.assertEqual(actual_version, LooseVersion("1.8.5.2"))
 
     @mock.patch("jirafs.utils.subprocess.check_output")
     def test_parse_linux_git_version(self, git_version_output):
@@ -51,4 +51,4 @@ class TestParseGitVersion(BaseTestCase):
 
         actual_version = utils.get_git_version()
 
-        self.assertEqual(actual_version, NormalizedVersion("1.9.1"))
+        self.assertEqual(actual_version, LooseVersion("1.9.1"))


### PR DESCRIPTION
``verlib`` package seems like something very obsolete. Trying to remove it, but I am still having problems with tests:
```
[   68s] ======================================================================
[   68s] ERROR: test_push_no_changes (tests.commands.test_push.TestPushCommand)
[   68s] ----------------------------------------------------------------------
[   68s] Traceback (most recent call last):
[   68s]   File "/home/abuild/rpmbuild/BUILD/jirafs-1.17.1/tests/commands/test_push.py", line 13, in setUp
[   68s]     super(TestPushCommand, self).setUp()
[   68s]   File "/home/abuild/rpmbuild/BUILD/jirafs-1.17.1/tests/commands/base.py", line 33, in setUp
[   68s]     self.arbitrary_ticket_number,
[   68s]   File "/home/abuild/rpmbuild/BUILD/jirafs-1.17.1/jirafs/utils.py", line 92, in run_command_method_with_kwargs
[   68s]     installed_commands = get_installed_commands()
[   68s]   File "/home/abuild/rpmbuild/BUILD/jirafs-1.17.1/jirafs/utils.py", line 102, in get_installed_commands
[   68s]     loaded_class = entry_point.load()
[   68s]   File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2345, in load
[   68s]     self.require(*args, **kwargs)
[   68s]   File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2368, in require
[   68s]     items = working_set.resolve(reqs, env, installer, extras=self.extras)
[   68s]   File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 789, in resolve
[   68s]     raise VersionConflict(dist, req).with_context(dependent_req)
[   68s] pkg_resources.VersionConflict: (prettytable 0.7 (/usr/lib/python3.6/site-packages), Requirement.parse('PrettyTable<1.0,>=0.7.2'))
```
Full [build log](https://github.com/coddingtonbear/jirafs/files/2771075/_log.txt)
