### PR TITLE
Adding a .encode() to value

### DIFF
--- a/jirafs/commands/merge.py
+++ b/jirafs/commands/merge.py
@@ -42,7 +42,7 @@ class Command(CommandPlugin):
                     u"Field {field} changed: \"{fr}\" -> \"{to}\"".format(
                         field=field,
                         fr=self.truncate_field_value(values[0]),
-                        to=self.truncate_field_value(values[1])
+                        to=self.truncate_field_value(values[1]).encode()
                     )
                 )
 


### PR DESCRIPTION
I was doing a "jirafs clone" and got a traceback, so I added this decode() call to work around this:

```--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.6/logging/__init__.py", line 996, in emit
    stream.write(msg)
UnicodeEncodeError: 'ascii' codec can't encode character '\u2026' in position 77: ordinal not in range(128)
Call stack:
  File "/home/sean/projects/jiraimport/venv/bin/jirafs", line 11, in <module>
    sys.exit(main())
  File "/home/sean/projects/jiraimport/venv/lib/python3.6/site-packages/jirafs/cmdline.py", line 135, in main
    extra, jira=jira, path=args.folder, command_name=command_name
  File "/home/sean/projects/jiraimport/venv/lib/python3.6/site-packages/jirafs/plugin.py", line 266, in execute_command
    cmd.handle(**kwargs)
  File "/home/sean/projects/jiraimport/venv/lib/python3.6/site-packages/jirafs/commands/clone.py", line 37, in handle
    return self.cmd(path, ticket_url, jira)
  File "/home/sean/projects/jiraimport/venv/lib/python3.6/site-packages/jirafs/plugin.py", line 307, in cmd
    self.main(*args, **kwargs)
  File "/home/sean/projects/jiraimport/venv/lib/python3.6/site-packages/jirafs/commands/clone.py", line 188, in main
    jira,
  File "/home/sean/projects/jiraimport/venv/lib/python3.6/site-packages/jirafs/commands/clone.py", line 48, in clone_from_issue
    utils.run_command_method_with_kwargs('pull', folder=folder)
  File "/home/sean/projects/jiraimport/venv/lib/python3.6/site-packages/jirafs/utils.py", line 97, in run_command_method_with_kwargs
    return getattr(installed_commands[command](), method)(**kwargs)
  File "/home/sean/projects/jiraimport/venv/lib/python3.6/site-packages/jirafs/commands/pull.py", line 14, in main
    merge_result = run_command_method_with_kwargs('merge', folder=folder)
  File "/home/sean/projects/jiraimport/venv/lib/python3.6/site-packages/jirafs/utils.py", line 97, in run_command_method_with_kwargs
    return getattr(installed_commands[command](), method)(**kwargs)
  File "/home/sean/projects/jiraimport/venv/lib/python3.6/site-packages/jirafs/commands/merge.py", line 46, in main
    to=self.truncate_field_value(values[1])
  File "/home/sean/projects/jiraimport/venv/lib/python3.6/site-packages/jirafs/ticketfolder.py", line 1014, in log
    self.logger.log(level, message, *args)
Message: '{FG-1} Field description changed: "" -> "Description.  *Bold text+Unde\u2026"'
Arguments: ()
```