### PR TITLE
Teach subtask to override issuetype with --issuetype

### DIFF
--- a/jirafs/commands/subtask.py
+++ b/jirafs/commands/subtask.py
@@ -11,14 +11,17 @@ class Command(CommandPlugin):
     def main(self, folder, args, **kwargs):
         summary = " ".join(args.summary)
 
-        folder.jira.create_issue(
-            fields={
-                "project": {"key": folder.issue.fields.project.key},
-                "summary": summary,
-                "issuetype": {"name": "Sub-task"},
-                "parent": {"id": folder.issue.key},
-            }
-        )
+        issue_data = {
+            "project": {"key": folder.issue.fields.project.key},
+            "summary": summary,
+            "issuetype": {"name": "Sub-task"},
+            "parent": {"id": folder.issue.key},
+        }
+
+        if args.issuetype is not None:
+            issue_data["issuetype"]["name"] = args.issuetype
+
+        folder.jira.create_issue(fields=issue_data)
 
         commands = utils.get_installed_commands()
         jira = utils.lazy_get_jira()
@@ -28,3 +31,4 @@ class Command(CommandPlugin):
 
     def add_arguments(self, parser):
         parser.add_argument("summary", nargs="+")
+        parser.add_argument("--issuetype", default=None, type=str)


### PR DESCRIPTION
Like `jirafs create` takes `--issuetype` to override the default issue
type, teach `jirafs subtask` to do the same for sub tasks.