### PR TITLE
Replace ThreadingHTTPServer with plain HTTPServer

### DIFF
--- a/jirafs/commands/preview/__init__.py
+++ b/jirafs/commands/preview/__init__.py
@@ -8,7 +8,7 @@ import time
 import traceback
 import uuid
 import webbrowser
-from http.server import ThreadingHTTPServer
+from http.server import HTTPServer
 from http.server import SimpleHTTPRequestHandler
 
 from dateutil.parser import parse
@@ -344,7 +344,7 @@ class Command(CommandPlugin):
             IssueRequestHandler.folder = folder
             IssueRequestHandler.get_converted_markup = get_converted_markup
 
-            server = ThreadingHTTPServer(("", port), IssueRequestHandler)
+            server = HTTPServer(("", port), IssueRequestHandler)
             server.timeout = 0.1
             print(f"Serving from http://127.0.0.1:{port}")
             print("Press <Ctrl+C> to Exit")


### PR DESCRIPTION
`ThreadingHTTPServer` was added in Python 3.7. jirafs claims compatibility
with Python >= 3.6 and openSUSE Leap 15.2 uses 3.6. We can backport [1]
or conditionally import [2] `ThreadingHTTPServer`, but the plain
`HTTPServer` seems to work fine for previews.

[1] https://gist.github.com/pankajp/280596a5dabaeeceaaaa
[2] https://stackoverflow.com/a/3496632/482758

Fixes: coddingtonbear/jirafs#65