### PR TITLE
Switch to unittest.mock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 - curl -fI $INTEGRATION_TESTING_URL
 - pip install --upgrade setuptools
 - pip install -r requirements.txt
-- pip install pytest mock behave
+- pip install pytest behave
 - pip install -e .
 - git config --global user.email "gitbot@adamcoddington.net"
 - git config --global user.name "I'm a Robot"

--- a/tests/commands/base.py
+++ b/tests/commands/base.py
@@ -1,8 +1,8 @@
 import os
 import tempfile
 
-import mock
-from mock import patch
+from unittest import mock
+from unittest.mock import patch
 
 from jirafs.utils import run_command_method_with_kwargs
 

--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -1,4 +1,4 @@
-from mock import call, patch
+from unittest.mock import call, patch
 
 from jirafs.utils import run_command_method_with_kwargs
 

--- a/tests/test_command_result.py
+++ b/tests/test_command_result.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from jirafs.plugin import CommandResult
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -3,8 +3,8 @@ import os
 import shutil
 import tempfile
 
-import mock
-from mock import patch
+from unittest import mock
+from unittest.mock import patch
 
 from jirafs.plugin import MacroPlugin
 from jirafs.utils import run_command_method_with_kwargs

--- a/tests/test_ticketfolder.py
+++ b/tests/test_ticketfolder.py
@@ -4,9 +4,9 @@ import os
 import shutil
 import tempfile
 
-import mock
+from unittest import mock
 import six
-from mock import patch
+from unittest.mock import patch
 
 from jirafs import exceptions
 from jirafs.jirafieldmanager import JiraFieldManager
@@ -63,7 +63,7 @@ class TestTicketFolder(BaseTestCase):
 
         expected_result = json.loads(self.get_asset_contents("basic.status.json"))
 
-        self.assertEquals(actual_result, expected_result)
+        self.assertEqual(actual_result, expected_result)
 
     def test_fetch(self):
         self.ticketfolder._issue = self.rehydrate_issue("test_fetch/fetched.json")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from distutils.version import LooseVersion
 
-import mock
+from unittest import mock
 
 from jirafs import utils
 


### PR DESCRIPTION
Python 3.3+ has included mock in the standard library, under the unittest module. Switch to using that, rather than the external mock library.

Fixes #69